### PR TITLE
Fix crypt3.sh

### DIFF
--- a/Crypt3.xcodeproj/project.pbxproj
+++ b/Crypt3.xcodeproj/project.pbxproj
@@ -322,7 +322,7 @@
 		AA6CC8D10A364A6500A10E61 /* Development */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				ARCHS = "$(ARCHS_STANDARD)";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -346,7 +346,7 @@
 		AA6CC8D20A364A6500A10E61 /* Deployment */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				ARCHS = "$(ARCHS_STANDARD)";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
@@ -368,7 +368,7 @@
 		AA6CC8D30A364A6500A10E61 /* Default */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				ARCHS = "$(ARCHS_STANDARD)";
 				COMBINE_HIDPI_IMAGES = YES;
 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;

--- a/Crypt3.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Crypt3.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/scripts/crypt3.sh
+++ b/scripts/crypt3.sh
@@ -10,16 +10,16 @@ usage () {
     exit 1
 }
 
-if [[ $# != 4 ]]; then
+if [[ $# != 5 && $# != 6 ]]; then
     usage
 fi
 
-opensslexe=`which openssl`
-command=${1}
-shred=${2}
-key=${3}
-filePath=${4}
-skipChecks=${5}
+opensslexe=${1}
+command=${2}
+shred=${3}
+key=${4}
+filePath=${5}
+skipChecks=${6}
 cipher="aes-256-cbc"
 
 keyHash=`echo "${key}" | $opensslexe dgst -sha1 | awk '{ print substr($1, 0, 4) }'`


### PR DESCRIPTION
This PR updates project architecture settings to satisfy modern Xcode. It also fixes arguments parsing in the `crypt3.sh` script, so the program works as expected.